### PR TITLE
[fix] Add apt-transport-https before adding gogs

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -19,13 +19,17 @@ sudo yunohost app initdb $app -p $db_pwd
 sudo yunohost app setting $app mysqlpwd -v $db_pwd
 # sudo yunohost app setting $app adminusername -v $admin
 
+# Add apt-transport-https before adding gogs repor
+sudo apt-get update
+sudo apt-get -y install apt-transport-https
+
 # Add repository
 sudo wget -qO - https://deb.packager.io/key | sudo apt-key add -
 sudo echo "deb https://deb.packager.io/gh/pkgr/gogs wheezy pkgr" | sudo tee /etc/apt/sources.list.d/gogs.list
 
 # install gogs
 sudo apt-get update
-sudo apt-get -y install gogs apt-transport-https
+sudo apt-get -y install gogs
 
 # repository path
 repo_path=/home/yunohost.app/$app


### PR DESCRIPTION
With actual solution : apt-transport-https is installed after we need it. With this patch : if we don't try to install gogs before : installing gogs work.

If we try to install it before : it brea at the first apt-get update : need to remove gogs.list before update

Maybe:

```
if [ -e /etc/apt/sources.list.d/gogs.list ]
    sudo rm /etc/apt/sources.list.d/gogs.list
```
